### PR TITLE
Adding option to deprioritize menu entries for locked items/actions

### DIFF
--- a/src/main/java/com/chanceman/ChanceManConfig.java
+++ b/src/main/java/com/chanceman/ChanceManConfig.java
@@ -101,10 +101,18 @@ public interface ChanceManConfig extends Config
     default boolean showGemDropTable() { return true; }
 
     @ConfigItem(
+            keyName = "deprioritizeLockedOptions",
+            name = "Deprioritize Locked Menu Options",
+            description = "Sorts locked menu options below the Walk Here option.",
+            position = 11
+    )
+    default boolean deprioritizeLockedOptions() { return true; }
+
+    @ConfigItem(
             keyName = "unlockedItemColor",
             name = "Unlocked Item Color",
             description = "Color of the unlocked item name in chat messages.",
-            position = 11
+            position = 12
     )
     default Color unlockedItemColor()
     {
@@ -115,7 +123,7 @@ public interface ChanceManConfig extends Config
             keyName = "rolledItemColor",
             name = "Rolled Item Color",
             description = "Color of the item used to unlock another item.",
-            position = 12
+            position = 13
     )
     default Color rolledItemColor()
     {
@@ -126,7 +134,7 @@ public interface ChanceManConfig extends Config
             keyName = "dimLockedItemsEnabled",
             name = "Dim locked items",
             description = "Dim any item icons that have not been unlocked.",
-            position = 13
+            position = 14
     )
     default boolean dimLockedItemsEnabled()
     {
@@ -138,7 +146,7 @@ public interface ChanceManConfig extends Config
             keyName = "dimLockedItemsOpacity",
             name = "Dim opacity",
             description = "0 = no dim (fully visible), 255 = fully transparent.",
-            position = 14
+            position = 15
     )
     default int dimLockedItemsOpacity()
     {

--- a/src/main/java/com/chanceman/menus/ActionHandler.java
+++ b/src/main/java/com/chanceman/menus/ActionHandler.java
@@ -1,5 +1,6 @@
 package com.chanceman.menus;
 
+import com.chanceman.ChanceManConfig;
 import com.chanceman.ChanceManPlugin;
 import com.chanceman.managers.UnlockedItemsManager;
 import lombok.Getter;
@@ -65,6 +66,8 @@ public class ActionHandler {
 	private Client client;
 	@Inject
 	private EventBus eventBus;
+    @Inject
+    private ChanceManConfig config;
 	@Inject
 	private ChanceManPlugin plugin;
 	@Inject
@@ -130,6 +133,9 @@ public class ActionHandler {
 			entry.setOption("<col=808080>" + option);
 			entry.setTarget("<col=808080>" + target);
 			entry.onClick(DISABLED);
+            if (config.deprioritizeLockedOptions()) {
+                entry.setDeprioritized(true);
+            }
 		}
 	}
 


### PR DESCRIPTION
Added a config option to deprioritize locked menu options. Basically whenever a menu option would already be greyed out, it will then be deprioritized depending on the setting.