### PR TITLE
Blocking Swift Blade in F2P. According to the wiki, players must have…

### DIFF
--- a/src/main/java/com/chanceman/filters/FreeToPlayBlockedItems.java
+++ b/src/main/java/com/chanceman/filters/FreeToPlayBlockedItems.java
@@ -17,6 +17,7 @@ public enum FreeToPlayBlockedItems {
     CursedAmuletOfMagic(ItemID.AMULET_OF_MAGIC_CURSED),
     Dust(ItemID.DUST),
     Fur(ItemID.FUR),
+    SwiftBlade(ItemID.SWIFT_BLADE),
 
     // Dyed boots and gloves
     GreyBoots(ItemID.WOLFENBOOTS_GREY),


### PR DESCRIPTION
Blocking Swift Blade from being rollable in F2P. According to the wiki, linked below, players must have 48 hours of playtime as a member in order to purchase items from the LMS shop.

https://oldschool.runescape.wiki/w/Justine%27s_stuff_for_the_Last_Shopper_Standing