### PR TITLE
Avoid blocking executor shutdowns

### DIFF
--- a/src/main/java/com/chanceman/ChanceManPlugin.java
+++ b/src/main/java/com/chanceman/ChanceManPlugin.java
@@ -217,17 +217,9 @@ public class ChanceManPlugin extends Plugin
         if (fileExecutor != null)
         {
             fileExecutor.shutdown(); // stop accepting new tasks
-            try
+            if (!fileExecutor.isTerminated())
             {
-                if (!fileExecutor.awaitTermination(1500, java.util.concurrent.TimeUnit.MILLISECONDS))
-                {
-                    fileExecutor.shutdownNow(); // cancel leftovers if they hang
-                }
-            }
-            catch (InterruptedException ie)
-            {
-                fileExecutor.shutdownNow();
-                Thread.currentThread().interrupt();
+                fileExecutor.shutdownNow(); // cancel leftovers if they hang
             }
             fileExecutor = null;
 

--- a/src/main/java/com/chanceman/drops/DropCache.java
+++ b/src/main/java/com/chanceman/drops/DropCache.java
@@ -438,22 +438,17 @@ public class DropCache
         }
 
         executor.shutdown();
-        try {
-            if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
-                executor.shutdownNow();
-                if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
-                    log.warn("dropcache-io executor did not terminate cleanly");
-                }
-            }
-        } catch (InterruptedException ie) {
+        if (!executor.isTerminated()) {
             executor.shutdownNow();
-            Thread.currentThread().interrupt();
-        } finally {
-            ioExecutor = null;
-            cache.clear();
-            nameIndex.clear();
-            indexLoaded = false;
+            if (!executor.isTerminated()) {
+                log.warn("dropcache-io executor did not terminate cleanly");
+            }
         }
+
+        ioExecutor = null;
+        cache.clear();
+        nameIndex.clear();
+        indexLoaded = false;
     }
 
     private synchronized ExecutorService ensureExecutor() {


### PR DESCRIPTION
## Summary
- stop blocking on the file executor during plugin shutdown
- remove awaitTermination calls from the drop cache shutdown while keeping cancellation and logging

## Testing
- ./gradlew check *(fails: unable to download dependencies due to HTTP 403 from Maven repos)*

------
https://chatgpt.com/codex/tasks/task_b_68d7e86eb8cc832a9915a8c1125b3477